### PR TITLE
chore: add default_version and codeowner_team to .repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -11,6 +11,6 @@
     "distribution_name": "google-cloud-bigquery-connection",
     "api_id": "bigqueryconnection.googleapis.com",
     "requires_billing": true,
-    "default_version": "",
-    "codeowner_team": ""
+    "default_version": "v1",
+    "codeowner_team": "@googleapis/api-bigquery"
 }

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,14 +1,16 @@
 {
-"name": "bigqueryconnection",
-"name_pretty": "Google BigQuery Connection",
-"product_documentation": "https://cloud.google.com/bigquery/docs/reference/bigqueryconnection",
-"client_documentation": "https://googleapis.dev/python/bigqueryconnection/latest",
-"issue_tracker": "",
-"release_level": "ga",
-"language": "python",
-"library_type": "GAPIC_AUTO",
-"repo": "googleapis/python-bigquery-connection",
-"distribution_name": "google-cloud-bigquery-connection",
-"api_id": "bigqueryconnection.googleapis.com",
-"requires_billing": true
+    "name": "bigqueryconnection",
+    "name_pretty": "Google BigQuery Connection",
+    "product_documentation": "https://cloud.google.com/bigquery/docs/reference/bigqueryconnection",
+    "client_documentation": "https://googleapis.dev/python/bigqueryconnection/latest",
+    "issue_tracker": "",
+    "release_level": "ga",
+    "language": "python",
+    "library_type": "GAPIC_AUTO",
+    "repo": "googleapis/python-bigquery-connection",
+    "distribution_name": "google-cloud-bigquery-connection",
+    "api_id": "bigqueryconnection.googleapis.com",
+    "requires_billing": true,
+    "default_version": "",
+    "codeowner_team": ""
 }


### PR DESCRIPTION
Set codeowner_team to @googleapis/api-bigquery as codeowner. Set default_version to v1. This change is needed for the following synthtool PRs.

googleapis/synthtool#1201
googleapis/synthtool#1114