### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "bigqueryconnection",
     "name_pretty": "Google BigQuery Connection",
     "product_documentation": "https://cloud.google.com/bigquery/docs/reference/bigqueryconnection",
-    "client_documentation": "https://googleapis.dev/python/bigqueryconnection/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/bigqueryconnection/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ Python Client for BigQuery Connection
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-bigquery-connection.svg
    :target: https://pypi.org/project/google-cloud-bigquery-connection/
 .. _BigQuery Connection API: https://cloud.google.com/bigquery/docs/reference/bigqueryconnection/rest
-.. _Client Library Documentation: https://googleapis.dev/python/bigqueryconnection/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/bigqueryconnection/latest
 .. _Product Documentation:  https://cloud.google.com/bigquery/docs/reference/bigqueryconnection/rest
 .. _Introduction to BigQuery external data sources:  https://cloud.google.com/bigquery/external-data-sources
 


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.