### PR TITLE
fix: Use unittest.mock if available

### DIFF
--- a/tests/unit/gapic/bigquery_connection_v1/test_connection_service.py
+++ b/tests/unit/gapic/bigquery_connection_v1/test_connection_service.py
@@ -30,7 +30,10 @@ from google.protobuf import field_mask_pb2  # type: ignore
 from google.type import expr_pb2  # type: ignore
 import grpc
 from grpc.experimental import aio
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 from proto.marshal.rules.dates import DurationRule, TimestampRule
 import pytest
 


### PR DESCRIPTION
The `mock` module is deprecated in recent Python versions.

Signed-off-by: Major Hayden <major@mhtx.net>

Fixes #212 🦕
